### PR TITLE
[#4] Add tests for .cabal parsing

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -74,11 +74,13 @@ test-suite extensions-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  other-modules:       Test.Extensions.Parser
+  other-modules:       Test.Extensions.Cabal
+                       Test.Extensions.Parser
   build-depends:       extensions
                      , ghc-boot-th
                      , hspec
                      , text ^>= 1.2
+                     , unordered-containers
   ghc-options:         -threaded
                        -rtsopts
                        -with-rtsopts=-N

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,8 +2,11 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 
+import Test.Extensions.Cabal (cabalSpec)
 import Test.Extensions.Parser (parserSpec)
 
 
 main :: IO ()
-main = hspec parserSpec
+main = hspec $ do
+    cabalSpec
+    parserSpec

--- a/test/Test/Extensions/Cabal.hs
+++ b/test/Test/Extensions/Cabal.hs
@@ -1,0 +1,48 @@
+module Test.Extensions.Cabal
+    ( cabalSpec
+    ) where
+
+import GHC.LanguageExtensions.Type (Extension (..))
+import Test.Hspec (Spec, describe, it, runIO, shouldBe)
+
+import Extensions.Cabal (parseCabalExtensions)
+
+import qualified Data.HashMap.Strict as HM
+
+
+cabalSpec :: Spec
+cabalSpec = describe "Cabal file Extensions Parser" $ do
+    extensionsMap <- runIO $ parseCabalExtensions "extensions.cabal"
+
+    it "should parse project Cabal file" $
+        extensionsMap `shouldBe` expectedMap
+  where
+    expectedMap :: HM.HashMap FilePath [Extension]
+    expectedMap = HM.fromList
+        [ "src/Extensions.hs"              `to` defaultExtensions
+        , "src/Extensions/Cabal.hs"        `to` defaultExtensions
+        , "src/Extensions/Parser.hs"       `to` defaultExtensions
+        , "test/Test/Extensions/Cabal.hs"  `to` defaultExtensions
+        , "test/Test/Extensions/Parser.hs" `to` defaultExtensions
+        , "test/Spec.hs"                   `to` defaultExtensions
+        ]
+      where
+        to = (,)
+
+    defaultExtensions :: [Extension]
+    defaultExtensions =
+        [ ConstraintKinds
+        , DeriveGeneric
+        , DerivingStrategies
+        , GeneralizedNewtypeDeriving
+        , InstanceSigs
+        , KindSignatures
+        , LambdaCase
+        , OverloadedStrings
+        , RecordWildCards
+        , ScopedTypeVariables
+        , StandaloneDeriving
+        , TupleSections
+        , TypeApplications
+        , ViewPatterns
+        ]


### PR DESCRIPTION
Resolves #4

Unfortunately, I was able to test only on the `extensions` itself :disappointed: The implementation of the `parseCabalExtensions` requires `IO` and actually tries to check whether modules actually exist. To test different Cabal files, we need to change the implementation of `parseCabalExtensions` somehow :thinking: 