### PR TITLE
[#44] Handle Cabal packages without the `hs-source-dirs` field

### DIFF
--- a/src/Extensions/Parser.hs
+++ b/src/Extensions/Parser.hs
@@ -166,7 +166,11 @@ commentP = newLines *> (try singleLineCommentP <|> try multiLineCommentP) <* new
         (string "{-" *> manyTill anyChar (try $ string "-}"))
 
 cppP :: Parser [a]
-cppP = [] <$ many newline <* try (char '#' <* noneOf "-") <* manyTill anyChar (try endOfLine)
+cppP =
+    [] <$ many newline
+       <* try (char '#' <* noneOf "-")
+       <* manyTill anyChar (try endOfLine)
+       <* newLines
 
 -- | Any combination of spaces and newlines.
 newLines :: Parser ()

--- a/test/Test/Extensions/Parser.hs
+++ b/test/Test/Extensions/Parser.hs
@@ -38,6 +38,7 @@ failSpec = describe "Expected test failures" $ do
 
 onlyExtensionsSpec :: Spec
 onlyExtensionsSpec = describe "Parsing only extensions without anything else" $ do
+    itShouldParse "" []
     itShouldParse "{-# LANGUAGE TypeApplications #-}" [TypeApplications]
     itShouldParse "{-# LaNgUaGe CPP #-}" [Cpp]
     itShouldParseOnOff "{-# LANGUAGE NoImplicitPrelude #-}" [Off ImplicitPrelude]
@@ -368,6 +369,17 @@ mixSpec = describe "Parsing combinations of different parts" $ do
         , "#-}"
         ])
         [TypeApplications, LambdaCase]
+    itShouldParse (unlines
+        [ "{-# LANGUAGE CPP #-}"
+        , "#if __GLASGOW_HASKELL__ >= 702"
+        , "{-# LANGUAGE Trustworthy #-}"
+        , "#endif"
+        , ""
+        , "-- |"
+        , "-- Module      : Data.ByteString.Base64"
+        ])
+        [Cpp]
+
 
 itShouldParse :: String -> [Extension] -> SpecWith (Arg Expectation)
 itShouldParse s = itShouldParseOnOff s . map On


### PR DESCRIPTION
Resolves #44