### PR TITLE
[#32] Test cabal parsing granularly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
     name: ghc ${{ matrix.ghc }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.0"]
+        cabal: ["3.2"]
         ghc:
           - "8.8.3"
           - "8.10.1"

--- a/src/Extensions/Parser.hs
+++ b/src/Extensions/Parser.hs
@@ -70,7 +70,9 @@ parseFile file = doesFileExist file >>= \hasFile ->
     else pure $ Left $ FileNotFound file
 
 {- | By the given file path and file source content, returns parsed list of
-'OnOffExtension's, if parsing succeeds.
+'OnOffExtension's, if parsing succeeds. This function takes a path to
+a Haskell source file. The path is only used for error message. Pass empty
+string or use 'parseSource', if you don't have a path to a Haskell module.
 -}
 parseSourceWithPath :: FilePath -> ByteString -> Either ParseError [OnOffExtension]
 parseSourceWithPath path src = case parse extensionsP path src of


### PR DESCRIPTION
Resolves #32

I was thinking about how to test Cabal handling better and came up with a simpler way to test different parts of cabal parsing without changing the library. I've also slightly improved the quality of Cabal parsing errors because I accidentally noticed a few helper functions in the Cabal library.