### PR TITLE
[#76] Update GitHub Actions to test newer GHC versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
           - "8.10.1"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v2
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store


### PR DESCRIPTION
* Switch to [haskell/actions/setup](https://github.com/haskell/actions/tree/main/setup).
* Bump cache and checkout versions.

Resolves #76.