### PR TITLE
[#78] Add CUSKs to the list of default 2010 extensions

### DIFF
--- a/src/Extensions/Types.hs
+++ b/src/Extensions/Types.hs
@@ -265,6 +265,9 @@ default2010Extensions =
     , PatternGuards
     , DoAndIfThenElse
     , RelaxedPolyRec
+#if __GLASGOW_HASKELL__ >= 810
+    , CUSKs
+#endif
     ]
 
 deriving stock instance Read Extension


### PR DESCRIPTION
`CUSKs` was added in 8.10.1 and enabled by default. See #78 for references.

Resolves #78.