### PR TITLE
Support Cabal-3.6

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -69,7 +69,7 @@ library
                          Extensions.Types
 
   build-depends:       bytestring ^>= 0.10
-                     , Cabal >= 3.0 && < 3.5
+                     , Cabal >= 3.0 && < 3.7
                      , containers ^>= 0.6
                      , directory ^>= 1.3
                      , filepath ^>= 1.4

--- a/src/Extensions/Cabal.hs
+++ b/src/Extensions/Cabal.hs
@@ -53,6 +53,10 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Language.Haskell.Extension as Cabal
 
+#if MIN_VERSION_Cabal(3,6,0)
+import Distribution.Utils.Path (getSymbolicPath)
+#endif
+
 
 {- | Parse default extensions from a @.cabal@ file under given
 'FilePath'.
@@ -144,7 +148,11 @@ condTreeToExtensions
 condTreeToExtensions extractModules extractBuildInfo condTree = do
     let comp = condTreeData condTree
     let buildInfo = extractBuildInfo comp
+#if MIN_VERSION_Cabal(3,6,0)
+    let srcDirs = getSymbolicPath <$> hsSourceDirs buildInfo
+#else
     let srcDirs = hsSourceDirs buildInfo
+#endif
     let modules = extractModules comp ++
             map toModulePath (otherModules buildInfo ++ autogenModules buildInfo)
     let (safeExts, parsedExtensionsAll) = partitionEithers $ mapMaybe cabalToGhcExtension $ defaultExtensions buildInfo


### PR DESCRIPTION
[`hsSourceDirs`](https://hackage.haskell.org/package/Cabal-3.6.0.0/docs/Distribution-Types-BuildInfo.html#v:hsSourceDirs) returns `[SymbolicPath]` in Cabal-3.6.

This uses `CPP` to check for a later version of `Cabal` and convert back to `[FilePath]` if needed, using [`Distribution.Utils.Path.getSymbolicPath`](https://hackage.haskell.org/package/Cabal-3.6.0.0/docs/Distribution-Utils-Path.html#v:getSymbolicPath).