### PR TITLE
Add flag to toggle building executable

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -19,6 +19,11 @@ tested-with:         GHC == 8.8.4
                      GHC == 8.10.7
                      GHC == 9.0.2
 
+flag executable
+  description: Build the extensions executable
+  default: True
+  manual: True
+
 source-repository head
   type:                git
   location:            https://github.com/kowainik/extensions.git
@@ -79,6 +84,8 @@ library
 
 executable extensions
   import:              common-options
+  if !flag(executable)
+    buildable: False
   hs-source-dirs:      app
   main-is:             Main.hs
   other-modules:       Cli


### PR DESCRIPTION
Some distributors need to use the old Cabal-v1 build systems, which will build the `extensions` executable even if it isn't needed (for instance when this package is only needed as a dependency for [`stan`](https://github.com/kowainik/stan/blob/dcbc8682a964ae6f642ae37adbd46f6545d39aa6/stan.cabal#L128)).

This adds a new `executable` flag (enabled by default) which will allow for disabling the `extensions` executable if it isn't needed.