### PR TITLE
bump `hspec-hedgehog`

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -131,7 +131,7 @@ test-suite extensions-test
                      , ghc-boot-th
                      , hedgehog >= 1.0 && < 1.5
                      , hspec
-                     , hspec-hedgehog ^>= 0.0.1
+                     , hspec-hedgehog >= 0.0.1
                      , text
   ghc-options:         -threaded
                        -rtsopts


### PR DESCRIPTION
https://hackage.haskell.org/package/hspec-hedgehog

succeeds:
```
cabal test --constraint 'hspec-hedgehog==0.1.1.0'
```

Closes #91 


Can a revision be pushed to Hackage?
This would help build `extensions` with Nix. NixPkgs `haskell-updates` is on `hspec-hedgehog` 0.1.1.0:
```
$ nix search nixpkgs/haskell-updates#haskellPackages hspec-hedgehog
* legacyPackages.x86_64-linux.haskellPackages.hspec-hedgehog (0.1.1.0)
  Integrate Hedgehog and Hspec!
```
Thanks