### PR TITLE
Support base < 4.21 (i.e. support GHC 9.10)

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -33,7 +33,7 @@ source-repository head
   location:            https://github.com/kowainik/extensions.git
 
 common common-options
-  build-depends:       base >= 4.13.0.0 && < 4.20
+  build-depends:       base >= 4.13.0.0 && < 4.21
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Also published a Hackage revision (revision 1): https://hackage.haskell.org/package/extensions-0.1.0.2/revisions/