### PR TITLE
bump upper bounds on `hedgehog` and `hspec-hedgehog`

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -131,9 +131,9 @@ test-suite extensions-test
                      , bytestring
                      , containers
                      , ghc-boot-th
-                     , hedgehog >= 1.0
+                     , hedgehog >= 1.0 && < 1.6
                      , hspec
-                     , hspec-hedgehog >= 0.0.1
+                     , hspec-hedgehog >= 0.0.1 && < 0.4
                      , text
   ghc-options:         -threaded
                        -rtsopts

--- a/extensions.cabal
+++ b/extensions.cabal
@@ -131,9 +131,9 @@ test-suite extensions-test
                      , bytestring
                      , containers
                      , ghc-boot-th
-                     , hedgehog >= 1.0 && < 1.5
+                     , hedgehog >= 1.0
                      , hspec
-                     , hspec-hedgehog >= 0.0.1 && < 0.2
+                     , hspec-hedgehog >= 0.0.1
                      , text
   ghc-options:         -threaded
                        -rtsopts


### PR DESCRIPTION
build succeeds:
```
cabal build -j --enable-tests --constraint 'hedgehog >= 1.5' --constraint 'hspec-hedgehog >= 0.3.0.0'
```

Please release a fix version for `extensions` to Hackage.