### PR TITLE
Only depend on Cabal-syntax

### DIFF
--- a/extensions.cabal
+++ b/extensions.cabal
@@ -86,15 +86,15 @@ library
 
   build-depends:       bytestring >= 0.10 && < 0.13
                        -- We need to pin a single major version of
-                       -- Cabal here because the main reason we use
-                       -- Cabal is for its list of extensions.  Later
+                       -- Cabal-syntax here because the main reason we use
+                       -- Cabal-syntax is for its list of extensions.  Later
                        -- versions have strictly more extensions, and
                        -- we'll have missing patterns if we try to
                        -- support more than one major version.  If
                        -- this causes problems in practice let's
                        -- revisit this decision and come up with
                        -- another approach.
-                     , Cabal ^>= 3.14
+                     , Cabal-syntax ^>= 3.14
                      , containers >= 0.6 && < 0.8
                      , directory ^>= 1.3
                      , filepath >= 1.4 && < 1.6

--- a/src/Extensions/Cabal.hs
+++ b/src/Extensions/Cabal.hs
@@ -41,7 +41,7 @@ import Distribution.Types.GenericPackageDescription (GenericPackageDescription (
 import Distribution.Types.Library (Library (..))
 import Distribution.Types.TestSuite (TestSuite (..))
 import Distribution.Types.TestSuiteInterface (TestSuiteInterface (..))
-#if MIN_VERSION_Cabal(3,6,0)
+#if MIN_VERSION_Cabal_syntax(3,6,0)
 import Distribution.Utils.Path (getSymbolicPath)
 #endif
 import GHC.LanguageExtensions.Type (Extension (..))
@@ -147,7 +147,7 @@ condTreeToExtensions
 condTreeToExtensions extractModules extractBuildInfo condTree = do
     let comp = condTreeData condTree
     let buildInfo = extractBuildInfo comp
-#if MIN_VERSION_Cabal(3,6,0)
+#if MIN_VERSION_Cabal_syntax(3,6,0)
     let srcDirs = getSymbolicPath <$> hsSourceDirs buildInfo
 #else
     let srcDirs = hsSourceDirs buildInfo


### PR DESCRIPTION
Because we don't need all of Cabal