### PR TITLE
Support GHC 9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - "9.8.1"
           - "9.10.1"
           - "9.12.1"
+          - "9.14.1"
 
     steps:
     - uses: actions/checkout@v4

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages: extensions.cabal
+
+allow-newer: boring:base

--- a/extensions.cabal
+++ b/extensions.cabal
@@ -34,7 +34,7 @@ source-repository head
   location:            https://github.com/kowainik/extensions.git
 
 common common-options
-  build-depends:       base >= 4.13.0.0 && < 4.22
+  build-depends:       base >= 4.13.0.0 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat
@@ -98,7 +98,7 @@ library
                      , containers >= 0.6 && < 0.9
                      , directory ^>= 1.3
                      , filepath >= 1.4 && < 1.6
-                     , ghc-boot-th >= 8.8.1 && < 9.13
+                     , ghc-boot-th >= 8.8.1 && < 9.15
                      , parsec ^>= 3.1
                      , text >= 1.2.3 && < 2.2
 


### PR DESCRIPTION
Use cabal.project to relax boring's bounds.  This will allow CI to run, but not leak into released sdists.